### PR TITLE
feat: add flag to specify number of verifier workers to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Metrics will be available at `http://localhost:2112/metrics`
 - `--balance.addresses`: Comma-separated Celestia addresses to monitor (enables balance checking)
 - `--balance.consensus-rpc-urls`: Comma-separated consensus RPC URLs for balance queries (required if balance.addresses is set)
 - `--balance.scrape-interval`: Balance check scrape interval in seconds (default: 30)
+- `--verifier.workers`: Number of concurrent workers for block verification (default: 50)
 - `--verbose`: Enable verbose logging (default: false)
 
 ### Example with Custom Endpoints

--- a/cmd/monitor.go
+++ b/cmd/monitor.go
@@ -42,6 +42,7 @@ const (
 	flagBalanceAddresses      = "balance.addresses"
 	flagBalanceRpcUrls        = "balance.consensus-rpc-urls"
 	flagBalanceScrapeInterval = "balance.scrape-interval"
+	flagVerifierWorkers       = "verifier.workers"
 
 	metricsPath = "/metrics"
 )
@@ -67,6 +68,7 @@ type flagValues struct {
 	balanceAddresses      string
 	balanceRpcUrls        string
 	balanceScrapeInterval int
+	verifierWorkers       int
 }
 
 func NewMonitorCmd() *cobra.Command {
@@ -99,6 +101,7 @@ func NewMonitorCmd() *cobra.Command {
 	cmd.Flags().StringVar(&flags.balanceAddresses, flagBalanceAddresses, "", "Comma-separated celestia addresses to monitor (enables balance checking)")
 	cmd.Flags().StringVar(&flags.balanceRpcUrls, flagBalanceRpcUrls, "", "Comma-separated consensus rpc urls for balance queries (required if balance.addresses is set)")
 	cmd.Flags().IntVar(&flags.balanceScrapeInterval, flagBalanceScrapeInterval, 30, "Balance check scrape interval in seconds (default: 30)")
+	cmd.Flags().IntVar(&flags.verifierWorkers, flagVerifierWorkers, 50, "Number of concurrent workers for block verification (default: 50)")
 
 	if err := cmd.MarkFlagRequired(flagHeaderNS); err != nil {
 		panic(err)
@@ -204,6 +207,7 @@ func monitorAndExportMetrics(_ *cobra.Command, _ []string) error {
 			cfg.HeaderNS,
 			cfg.DataNS,
 			flags.chainID,
+			flags.verifierWorkers,
 			logger,
 		),
 	}


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

Enables support for specifying the `--verifier.workers` to limit the number of go routines being created.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->
