### PR TITLE
fix: ensure time_since_last_block accuracy with polling fallback

### DIFF
--- a/pkg/exporters/drift/drift.go
+++ b/pkg/exporters/drift/drift.go
@@ -61,6 +61,9 @@ func (e exporter) ExportMetrics(ctx context.Context, m *metrics.Metrics) error {
 
 			m.RecordEndpointAvailability(e.chainID, e.referenceNode, true)
 			m.RecordReferenceBlockHeight(e.chainID, e.referenceNode, refHeight)
+			// Also update time since last block metric when we see new blocks via polling
+			// This ensures the metric stays accurate even if WebSocket subscription fails
+			m.UpdateLastBlockTime(e.chainID, time.Now())
 			e.logger.Info().Uint64("height", refHeight).Str("endpoint", e.referenceNode).Msg("recorded reference node height")
 
 			// get each full node height and calculate drift
@@ -76,6 +79,10 @@ func (e exporter) ExportMetrics(ctx context.Context, m *metrics.Metrics) error {
 				m.RecordEndpointAvailability(e.chainID, fullNode, true)
 				m.RecordCurrentBlockHeight(e.chainID, fullNode, currentHeight)
 				m.RecordBlockHeightDrift(e.chainID, fullNode, refHeight, currentHeight)
+
+				// Also update time since last block metric when we see new blocks via polling
+				// This ensures the metric stays accurate even if WebSocket subscription fails
+				m.UpdateLastBlockTime(e.chainID, time.Now())
 
 				drift := int64(refHeight) - int64(currentHeight)
 				e.logger.Info().

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -562,10 +562,7 @@ func (m *Metrics) RecordBlockTime(chainID string, arrivalTime time.Time) {
 		}
 	}
 
-	// update last seen arrival time
-	m.lastBlockArrivalTime[chainID] = arrivalTime
-	// reset time since last block to 0
-	m.TimeSinceLastBlock.WithLabelValues(chainID).Set(0)
+	m.updateLastBlockTimeUnsafe(chainID, arrivalTime)
 }
 
 // UpdateLastBlockTime updates the last block arrival time and resets time since last block metric
@@ -573,7 +570,13 @@ func (m *Metrics) RecordBlockTime(chainID string, arrivalTime time.Time) {
 func (m *Metrics) UpdateLastBlockTime(chainID string, arrivalTime time.Time) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	m.updateLastBlockTimeUnsafe(chainID, arrivalTime)
+}
 
+// updateLastBlockTimeUnsafe is an unexported helper that updates the last block arrival time
+// and resets the time since last block gauge.
+// This function is not thread-safe and should be called with a lock held.
+func (m *Metrics) updateLastBlockTimeUnsafe(chainID string, arrivalTime time.Time) {
 	// update last seen arrival time
 	m.lastBlockArrivalTime[chainID] = arrivalTime
 	// reset time since last block to 0

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -568,6 +568,18 @@ func (m *Metrics) RecordBlockTime(chainID string, arrivalTime time.Time) {
 	m.TimeSinceLastBlock.WithLabelValues(chainID).Set(0)
 }
 
+// UpdateLastBlockTime updates the last block arrival time and resets time since last block metric
+// without recording block time histogram. This is used by pollers that can't measure inter-block time.
+func (m *Metrics) UpdateLastBlockTime(chainID string, arrivalTime time.Time) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// update last seen arrival time
+	m.lastBlockArrivalTime[chainID] = arrivalTime
+	// reset time since last block to 0
+	m.TimeSinceLastBlock.WithLabelValues(chainID).Set(0)
+}
+
 // UpdateTimeSinceLastBlock updates the time_since_last_block metric for all chains
 // should be called periodically to keep the metric current.
 func (m *Metrics) UpdateTimeSinceLastBlock() {


### PR DESCRIPTION
## Problem
Two critical issues were identified in the metrics system:

1. **time_since_last_block_seconds showing outdated large values**: The metric was only updated by the verifier's WebSocket subscription, but when that failed, the metric would show increasingly large values (e.g., 220,366 seconds = ~2.5 days) even though the drift exporter's HTTP polling was correctly seeing new blocks at height 3,709,309.

2. **block_time_seconds_bucket corruption after ~190 blocks**: The initial fix attempt incorrectly used `RecordBlockTime()` in the drift exporter, which corrupted the block time histogram by recording invalid inter-block times from polling data.

## Solution
Implemented a proper separation of concerns between real-time and polling metrics:

1. **Added new `UpdateLastBlockTime()` method** in `pkg/metrics/metrics.go`:
   - Updates last block arrival time and resets time_since_last_block
   - Does NOT record block time histogram (unlike `RecordBlockTime()`)
   - Designed specifically for pollers that can't measure inter-block time

2. **Updated drift exporter** in `pkg/exporters/drift/drift.go`:
   - Changed from `RecordBlockTime()` to `UpdateLastBlockTime()`
   - Added calls when recording both reference node and full node heights
   - Provides redundancy for time_since_last_block metric

## Changes Made
- `pkg/metrics/metrics.go`: Added `UpdateLastBlockTime()` method
- `pkg/exporters/drift/drift.go`: Updated to use `UpdateLastBlockTime()` instead of `RecordBlockTime()`

## Impact
- ✅ `time_since_last_block_seconds` now stays accurate even if WebSocket fails
- ✅ `block_time_seconds_bucket` continues to work correctly for SLO calculations
- ✅ No more metric corruption after prolonged running
- ✅ Proper redundancy between real-time and polling metrics
- ✅ Maintains backward compatibility and all existing functionality

## Testing
- Build passes: `go build -o ev-metrics .`
- Tests pass: `go test ./...`
- No breaking changes to existing API
