### PR TITLE
fix(verifier): reconnect WebSocket on drop and add per-attempt RPC timeouts

### DIFF
--- a/pkg/exporters/verifier/verifier.go
+++ b/pkg/exporters/verifier/verifier.go
@@ -74,6 +74,10 @@ func (e *exporter) ExportMetrics(ctx context.Context, m *metrics.Metrics) error 
 
 	e.logger.Info().Int("workers", e.workers).Msg("started verification work pool")
 
+	// pre-initialize submission metrics so both blob types are always visible
+	// in Prometheus output, even before any block has been fully processed.
+	m.InitializeSubmissionMetrics(e.chainID)
+
 	// ticker to refresh submission duration metric every 10 seconds
 	refreshTicker := time.NewTicker(10 * time.Second)
 	defer refreshTicker.Stop()

--- a/pkg/exporters/verifier/verifier.go
+++ b/pkg/exporters/verifier/verifier.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	ethereum "github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/evstack/ev-metrics/internal/clients/celestia"
 	"github.com/evstack/ev-metrics/internal/clients/evm"
@@ -56,7 +57,6 @@ func (e *exporter) ExportMetrics(ctx context.Context, m *metrics.Metrics) error 
 	if err != nil {
 		return err
 	}
-	defer sub.Unsubscribe()
 
 	// create buffered channel for block queue
 	blockQueue := make(chan *types.Header, e.workers*2)
@@ -83,9 +83,27 @@ func (e *exporter) ExportMetrics(ctx context.Context, m *metrics.Metrics) error 
 		select {
 		case <-ctx.Done():
 			e.logger.Info().Msg("stopping block verification")
+			sub.Unsubscribe()
 			close(blockQueue)
 			workerGroup.Wait()
 			return nil
+		case subErr := <-sub.Err():
+			// WebSocket subscription dropped — reconnect with backoff.
+			if subErr != nil {
+				e.logger.Error().Err(subErr).Msg("WebSocket subscription error, reconnecting")
+			} else {
+				e.logger.Warn().Msg("WebSocket subscription closed, reconnecting")
+			}
+			sub.Unsubscribe()
+			newSub := e.reconnectSubscription(ctx, headers)
+			if newSub == nil {
+				// context was cancelled during reconnection
+				close(blockQueue)
+				workerGroup.Wait()
+				return nil
+			}
+			sub = newSub
+			e.logger.Info().Msg("WebSocket subscription re-established")
 		case <-refreshTicker.C:
 			// ensure that submission duration is always included in the 60 second window.
 			m.RefreshSubmissionDuration()
@@ -106,11 +124,39 @@ func (e *exporter) ExportMetrics(ctx context.Context, m *metrics.Metrics) error 
 			case blockQueue <- header:
 				// block queued successfully
 			case <-ctx.Done():
+				sub.Unsubscribe()
 				close(blockQueue)
 				workerGroup.Wait()
 				return nil
 			}
 		}
+	}
+}
+
+// reconnectSubscription attempts to re-establish the WebSocket block header subscription
+// with exponential backoff. Returns nil if the context is cancelled before reconnecting.
+func (e *exporter) reconnectSubscription(ctx context.Context, headers chan *types.Header) ethereum.Subscription {
+	backoff := 5 * time.Second
+	const maxBackoff = 60 * time.Second
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(backoff):
+		}
+
+		sub, err := e.evmClient.SubscribeNewHead(ctx, headers)
+		if err != nil {
+			e.logger.Warn().Err(err).Dur("retry_in", backoff).Msg("failed to reconnect WebSocket subscription, retrying")
+			if backoff*2 < maxBackoff {
+				backoff *= 2
+			} else {
+				backoff = maxBackoff
+			}
+			continue
+		}
+		return sub
 	}
 }
 
@@ -152,6 +198,12 @@ func (e *exporter) onVerified(m *metrics.Metrics, namespace string, blockHeight,
 		m.RecordMissingBlock(e.chainID, namespace, blockHeight)
 	}
 }
+
+// verifyAttemptTimeout caps how long a single verification attempt (all RPC calls
+// combined) may take. Without this, a slow or hung Celestia/ev-node endpoint can
+// block a worker goroutine indefinitely, eventually filling the block queue and
+// freezing metrics.
+const verifyAttemptTimeout = 30 * time.Second
 
 // verifyBlock attempts to verify a DA height for a given block status.
 func (e *exporter) verifyBlock(ctx context.Context, m *metrics.Metrics, header *types.Header) bool {
@@ -199,83 +251,7 @@ func (e *exporter) verifyBlock(ctx context.Context, m *metrics.Metrics, header *
 			// proceed with retry
 		}
 
-		blockResult, err := e.evnodeClient.GetBlock(ctx, blockHeight)
-		if err != nil {
-			logger.Warn().Err(err).Int("attempt", retries).Msg("failed to re-query block from ev-node")
-			continue
-		}
-
-		daHeight := blockResult.HeaderDaHeight
-		if namespace == "data" {
-			daHeight = blockResult.DataDaHeight
-		}
-
-		if daHeight == 0 {
-			logger.Debug().Int("attempt", retries).Msg("block still not submitted to DA, will retry")
-			continue
-		}
-
-		blockResultWithBlobs, err := e.evnodeClient.GetBlockWithBlobs(ctx, blockHeight)
-		if err != nil {
-			logger.Warn().Err(err).Int("attempt", retries).Msg("failed to query block from ev-node")
-			continue
-		}
-
-		daBlockTime, err := e.celestiaClient.GetBlockTimestamp(ctx, daHeight)
-		if err != nil {
-			logger.Warn().Err(err).Uint64("da_height", daHeight).Msg("failed to get da block timestamp")
-			continue
-		}
-
-		// the time taken from block time to DA inclusion time.
-		submissionDuration := daBlockTime.Sub(blockTime)
-
-		switch namespace {
-		case "header":
-			verified, err := e.celestiaClient.VerifyBlobAtHeight(ctx, blockResultWithBlobs.HeaderBlob, daHeight, e.headerNS)
-
-			if err != nil {
-				logger.Warn().Err(err).Uint64("da_height", daHeight).Msg("verification failed")
-				continue
-			}
-
-			if verified {
-				logger.Info().
-					Uint64("da_height", daHeight).
-					Dur("duration", time.Since(startTime)).
-					Msg("header blob verified on Celestia")
-				e.onVerified(m, namespace, blockHeight, daHeight, true, submissionDuration)
-				return false
-			}
-
-		case "data":
-			if len(blockResultWithBlobs.DataBlob) == 0 {
-				logger.Info().
-					Dur("duration", time.Since(startTime)).
-					Msg("empty data block - no verification needed")
-				e.onVerified(m, namespace, blockHeight, daHeight, true, submissionDuration)
-				return false
-			}
-
-			// perform actual verification between bytes from ev-node and Celestia.
-			verified, err := e.celestiaClient.VerifyDataBlobAtHeight(ctx, blockResultWithBlobs.DataBlob, daHeight, e.dataNS)
-			if err != nil {
-				logger.Warn().Err(err).Uint64("da_height", daHeight).Msg("verification failed")
-				continue
-			}
-
-			if verified {
-				logger.Info().
-					Uint64("da_height", daHeight).
-					Dur("duration", time.Since(startTime)).
-					Msg("data blob verified on Celestia")
-				e.onVerified(m, namespace, blockHeight, daHeight, true, submissionDuration)
-				return false
-			}
-			logger.Warn().Uint64("da_height", daHeight).Int("attempt", retries).Msg("verification failed, will retry")
-
-		default:
-			logger.Error().Str("namespace", namespace).Msg("unknown namespace type")
+		if e.verifyAttempt(ctx, m, logger, retries, blockHeight, namespace, blockTime, startTime) {
 			return false
 		}
 	}
@@ -284,4 +260,93 @@ func (e *exporter) verifyBlock(ctx context.Context, m *metrics.Metrics, header *
 	logger.Error().Msg("max retries exhausted: failed to verify block")
 	e.onVerified(m, namespace, blockHeight, 0, false, 0)
 	return true
+}
+
+// verifyAttempt performs one bounded RPC attempt to verify a block against Celestia DA.
+// It returns true when retrying is no longer needed (verified, or permanent failure),
+// and false when the caller should retry.
+// Each call is bounded by verifyAttemptTimeout so workers cannot hang indefinitely
+// on slow or unresponsive ev-node / Celestia endpoints.
+func (e *exporter) verifyAttempt(ctx context.Context, m *metrics.Metrics, logger zerolog.Logger, retries int, blockHeight uint64, namespace string, blockTime time.Time, startTime time.Time) bool {
+	attemptCtx, cancel := context.WithTimeout(ctx, verifyAttemptTimeout)
+	defer cancel()
+
+	blockResult, err := e.evnodeClient.GetBlock(attemptCtx, blockHeight)
+	if err != nil {
+		logger.Warn().Err(err).Int("attempt", retries).Msg("failed to re-query block from ev-node")
+		return false
+	}
+
+	daHeight := blockResult.HeaderDaHeight
+	if namespace == "data" {
+		daHeight = blockResult.DataDaHeight
+	}
+
+	if daHeight == 0 {
+		logger.Debug().Int("attempt", retries).Msg("block still not submitted to DA, will retry")
+		return false
+	}
+
+	blockResultWithBlobs, err := e.evnodeClient.GetBlockWithBlobs(attemptCtx, blockHeight)
+	if err != nil {
+		logger.Warn().Err(err).Int("attempt", retries).Msg("failed to query block from ev-node")
+		return false
+	}
+
+	daBlockTime, err := e.celestiaClient.GetBlockTimestamp(attemptCtx, daHeight)
+	if err != nil {
+		logger.Warn().Err(err).Uint64("da_height", daHeight).Msg("failed to get da block timestamp")
+		return false
+	}
+
+	// the time taken from block time to DA inclusion time.
+	submissionDuration := daBlockTime.Sub(blockTime)
+
+	switch namespace {
+	case "header":
+		verified, err := e.celestiaClient.VerifyBlobAtHeight(attemptCtx, blockResultWithBlobs.HeaderBlob, daHeight, e.headerNS)
+		if err != nil {
+			logger.Warn().Err(err).Uint64("da_height", daHeight).Msg("verification failed")
+			return false
+		}
+		if verified {
+			logger.Info().
+				Uint64("da_height", daHeight).
+				Dur("duration", time.Since(startTime)).
+				Msg("header blob verified on Celestia")
+			e.onVerified(m, namespace, blockHeight, daHeight, true, submissionDuration)
+			return true
+		}
+
+	case "data":
+		if len(blockResultWithBlobs.DataBlob) == 0 {
+			logger.Info().
+				Dur("duration", time.Since(startTime)).
+				Msg("empty data block - no verification needed")
+			e.onVerified(m, namespace, blockHeight, daHeight, true, submissionDuration)
+			return true
+		}
+
+		// perform actual verification between bytes from ev-node and Celestia.
+		verified, err := e.celestiaClient.VerifyDataBlobAtHeight(attemptCtx, blockResultWithBlobs.DataBlob, daHeight, e.dataNS)
+		if err != nil {
+			logger.Warn().Err(err).Uint64("da_height", daHeight).Msg("verification failed")
+			return false
+		}
+		if verified {
+			logger.Info().
+				Uint64("da_height", daHeight).
+				Dur("duration", time.Since(startTime)).
+				Msg("data blob verified on Celestia")
+			e.onVerified(m, namespace, blockHeight, daHeight, true, submissionDuration)
+			return true
+		}
+		logger.Warn().Uint64("da_height", daHeight).Int("attempt", retries).Msg("verification failed, will retry")
+
+	default:
+		logger.Error().Str("namespace", namespace).Msg("unknown namespace type")
+		return true
+	}
+
+	return false
 }

--- a/pkg/exporters/verifier/verifier.go
+++ b/pkg/exporters/verifier/verifier.go
@@ -78,14 +78,20 @@ func (e *exporter) ExportMetrics(ctx context.Context, m *metrics.Metrics) error 
 	refreshTicker := time.NewTicker(10 * time.Second)
 	defer refreshTicker.Stop()
 
+	// shutdown cleanly unsubscribes and waits for all workers to finish.
+	// It captures sub by reference so reassignment during reconnection is reflected.
+	shutdown := func() {
+		sub.Unsubscribe()
+		close(blockQueue)
+		workerGroup.Wait()
+	}
+
 	// main subscription loop
 	for {
 		select {
 		case <-ctx.Done():
 			e.logger.Info().Msg("stopping block verification")
-			sub.Unsubscribe()
-			close(blockQueue)
-			workerGroup.Wait()
+			shutdown()
 			return nil
 		case subErr := <-sub.Err():
 			// WebSocket subscription dropped — reconnect with backoff.
@@ -124,9 +130,7 @@ func (e *exporter) ExportMetrics(ctx context.Context, m *metrics.Metrics) error 
 			case blockQueue <- header:
 				// block queued successfully
 			case <-ctx.Done():
-				sub.Unsubscribe()
-				close(blockQueue)
-				workerGroup.Wait()
+				shutdown()
 				return nil
 			}
 		}
@@ -148,12 +152,12 @@ func (e *exporter) reconnectSubscription(ctx context.Context, headers chan *type
 
 		sub, err := e.evmClient.SubscribeNewHead(ctx, headers)
 		if err != nil {
-			e.logger.Warn().Err(err).Dur("retry_in", backoff).Msg("failed to reconnect WebSocket subscription, retrying")
 			if backoff*2 < maxBackoff {
 				backoff *= 2
 			} else {
 				backoff = maxBackoff
 			}
+			e.logger.Warn().Err(err).Dur("retry_in", backoff).Msg("failed to reconnect WebSocket subscription, retrying")
 			continue
 		}
 		return sub
@@ -317,6 +321,7 @@ func (e *exporter) verifyAttempt(ctx context.Context, m *metrics.Metrics, logger
 			e.onVerified(m, namespace, blockHeight, daHeight, true, submissionDuration)
 			return true
 		}
+		logger.Warn().Uint64("da_height", daHeight).Int("attempt", retries).Msg("header verification failed, will retry")
 
 	case "data":
 		if len(blockResultWithBlobs.DataBlob) == 0 {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -701,6 +701,25 @@ func (m *Metrics) RecordJsonRpcRequestDuration(chainID string, duration time.Dur
 	m.JsonRpcRequestDurationSummary.WithLabelValues(chainID).Observe(duration.Seconds())
 }
 
+// InitializeSubmissionMetrics pre-initializes submission-related metrics for all
+// known blob types so they are always visible in Prometheus output from startup,
+// regardless of whether any blocks have been processed yet.
+//
+// For Gauges and Counters, the label combination is registered at zero.
+// For the SubmissionDuration Summary, GetMetricWithLabelValues registers the
+// metric without making a fake observation — quantiles will show NaN and
+// count/sum will show 0, which accurately represents "no data yet".
+func (m *Metrics) InitializeSubmissionMetrics(chainID string) {
+	for _, blobType := range []string{"header", "data"} {
+		m.UnsubmittedBlocksTotal.WithLabelValues(chainID, blobType).Set(0)
+		m.SubmissionAttemptsTotal.WithLabelValues(chainID, blobType).Add(0)
+		m.SubmissionFailuresTotal.WithLabelValues(chainID, blobType).Add(0)
+		// Register the Summary without a fake observation so it is visible
+		// from startup while keeping quantile values accurate.
+		_, _ = m.SubmissionDuration.GetMetricWithLabelValues(chainID, blobType)
+	}
+}
+
 // InitializeJsonRpcSloThresholds initializes the constant SLO threshold gauges for JSON-RPC requests
 func (m *Metrics) InitializeJsonRpcSloThresholds(chainID string) {
 	m.JsonRpcRequestSloSeconds.WithLabelValues(chainID, "0.5").Set(0.2)


### PR DESCRIPTION
## Problem

Submission metrics silently stopped updating, requiring an application restart to recover. Additionally, some submission metrics were entirely absent from the Prometheus output even when the application was working correctly. No significant error logs appeared during either issue.

Three root causes were identified:

### 1. WebSocket subscription drop was never detected

The main `select` loop in `ExportMetrics` never listened on `sub.Err()`. When the go-ethereum WebSocket connection to the EVM node dropped, the error was silently swallowed. The `headers` channel simply stopped delivering new blocks — no log, no recovery, no metrics. The only way out was a restart.

### 2. Worker goroutines could hang indefinitely on Celestia/ev-node RPC calls

All calls inside `verifyBlock` — `GetBlock`, `GetBlockWithBlobs`, `GetBlockTimestamp`, `VerifyBlobAtHeight`, `VerifyDataBlobAtHeight` — used the root application context, which is only cancelled on shutdown. No per-call timeout existed.

If a Celestia or ev-node endpoint became slow or unresponsive, worker goroutines blocked indefinitely. Once all workers were stuck:
- The block queue filled (capacity = `workers * 2`)
- The main loop blocked on the inner `case blockQueue <- header:` send
- The refresh ticker (`RefreshSubmissionDuration`, `UpdateTimeSinceLastBlock`) stopped firing
- All submission metrics froze

### 3. Submission metrics were absent until first observation

`ev_metrics_unsubmitted_blocks_total`, `submission_duration_seconds`, `submission_attempts_total`, and `submission_failures_total` only appeared in Prometheus output after `onVerified()` was first called for a given `blob_type`. If no data block had completed verification yet (idle chain, blocks still in the retry loop, or no transaction blocks at all), the `blob_type=data` label combination was entirely absent — indistinguishable from a real failure.

## Fix

### WebSocket reconnection (`reconnectSubscription`)

Added `case subErr := <-sub.Err():` to the main select loop. On a subscription error, the current sub is cleanly unsubscribed and `reconnectSubscription()` retries with exponential backoff (5 s → 10 s → 20 s → 40 s → 60 s cap). The worker pool keeps running throughout — blocks already in the queue continue to be processed.

### Per-attempt RPC timeout (`verifyAttempt`)

Extracted the per-retry RPC logic from `verifyBlock` into a new `verifyAttempt()` method that creates a `context.WithTimeout(ctx, 30s)` and `defer cancel()`s it. Every call within a single attempt shares this bounded context. A worker is now guaranteed to free within 30 seconds per attempt regardless of endpoint availability, after which the existing backoff retry logic continues as before.

### Metric pre-initialization (`InitializeSubmissionMetrics`)

Added `InitializeSubmissionMetrics(chainID)` called from `ExportMetrics` at startup, which registers all submission metric label combinations before any block is processed:

- `UnsubmittedBlocksTotal`: `Set(0)` — "0 unsubmitted blocks" is a meaningful zero value
- `SubmissionAttemptsTotal` / `SubmissionFailuresTotal`: `Add(0)` — registers the counter at zero
- `SubmissionDuration`: `GetMetricWithLabelValues()` — registers the Summary without a fake observation; quantiles show `NaN` and count/sum show `0`, accurately representing "metric exists, no data observed yet"

### PR review feedback

- Extracted repeated shutdown sequence (`Unsubscribe + close + Wait`) into a closure to eliminate duplication across three select branches
- Fixed stale `retry_in` log in `reconnectSubscription`: backoff is now incremented before logging so the logged duration reflects the actual next wait
- Added missing warn log in the `"header"` verification branch when `VerifyBlobAtHeight` returns `verified=false`, matching the existing log in the `"data"` branch

## Test plan

- [ ] Verify application continues updating submission metrics after an EVM WebSocket disconnect (e.g. restart the EVM node while ev-metrics is running)
- [ ] Verify application continues updating submission metrics when Celestia node is temporarily slow/unresponsive
- [ ] Verify `ev_metrics_unsubmitted_blocks_total`, `submission_duration_seconds`, `submission_attempts_total`, and `submission_failures_total` all show both `blob_type=header` and `blob_type=data` immediately after startup
- [ ] Verify graceful shutdown still works correctly (ctx cancellation during reconnect loop exits cleanly)
- [ ] Verify existing tests pass: `go test ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable WebSocket subscriptions with explicit reconnect and graceful shutdown to avoid silent failures.
  * Per-attempt timeouts for verification to prevent hung calls and ensure retries follow backoff policies.
  * Improved error handling and logging to surface unknown states and retry reasons.

* **New Features**
  * Pre-initialized submission metrics for header and data blobs to ensure visibility in monitoring before processing.
  * Namespace-aware, multi-attempt verification flow with clearer success/retry signaling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->